### PR TITLE
Update 99-udev-rtirq.rules

### DIFF
--- a/99-udev-rtirq.rules
+++ b/99-udev-rtirq.rules
@@ -9,5 +9,5 @@
 #
 #   /usr/lib/udev/rules.d/99-udev-rtirq.rules
 
-ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card*", RUN+="/usr/bin/systemd-run /usr/sbin/udev-rtirq a $env{DEVPATH}"
-ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="card*", RUN+="/usr/bin/systemd-run /usr/sbin/udev-rtirq r $env{DEVPATH}"
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card*", RUN+="/usr/bin/systemd-run --no-block /usr/sbin/udev-rtirq a $env{DEVPATH}"
+ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="card*", RUN+="/usr/bin/systemd-run --no-block /usr/sbin/udev-rtirq r $env{DEVPATH}"


### PR DESCRIPTION
Prevent system-boot from stalling

Without this change booting debian/bullseye (systemd 247.2-5) on a Thinpad X1G8
make the command time out (3 min default delay). Exact cause is unknown, perhaps
an init ordering issue, the soundcard requires firmware (sof-audio-pci).